### PR TITLE
Fix :aws reference to :internetarchive in warning

### DIFF
--- a/lib/fog/bin/internet_archive.rb
+++ b/lib/fog/bin/internet_archive.rb
@@ -16,7 +16,7 @@ class InternetArchive < Fog::Bin
       @@connections ||= Hash.new do |hash, key|
         hash[key] = case key
         when :storage
-          Fog::Logger.warning("InternetArchive[:storage] is not recommended, use Storage[:aws] for portability")
+          Fog::Logger.warning("InternetArchive[:storage] is not recommended, use Fog::Storage[:internetarchive] for portability")
           Fog::Storage.new(:provider => 'InternetArchive')
         else
           raise ArgumentError, "Unrecognized service: #{key.inspect}"


### PR DESCRIPTION
A small thing, just noticed while I was reading the code.